### PR TITLE
Sending per-tool registration error to ROS

### DIFF
--- a/components/code/mtsAtracsysFusionTrack.cpp
+++ b/components/code/mtsAtracsysFusionTrack.cpp
@@ -538,7 +538,7 @@ void mtsAtracsysFusionTrack::Run(void)
         CMN_LOG_CLASS_RUN_ERROR << "Run: frame.threeDFiducialsVersionSize is invalid" << std::endl;
         break;
     default:
-        CMN_LOG_CLASS_RUN_ERROR << "Run: invalid status" << std::endl;
+        // CMN_LOG_CLASS_RUN_ERROR << "Run: invalid status" << std::endl; 
         break;
     case FTK_QS_NS::QS_OK:
         break;

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -64,7 +64,7 @@ if (cisst_FOUND_AS_REQUIRED)
 
     link_directories (${sawAtracsysFusionTrack_LIBRARY_DIR})
 
-    add_executable (atracsys_json src/atracsys_json.cpp)
+    add_executable (atracsys_json src/atracsys_json.cpp src/mts_ros_crtk_atracsys_bridge.cpp src/mts_ros_crtk_atracsys_bridge.h)
     target_link_libraries (atracsys_json
                            ${sawAtracsysFusionTrack_LIBRARIES}
                            ${catkin_LIBRARIES})

--- a/ros/src/atracsys_json.cpp
+++ b/ros/src/atracsys_json.cpp
@@ -26,7 +26,7 @@ http://www.cisst.org/cisst/license.txt.
 #include <sawAtracsysFusionTrack/mtsAtracsysFusionTrackStrayMarkersQtWidget.h>
 
 #include <ros/ros.h>
-#include <cisst_ros_crtk/mts_ros_crtk_bridge_provided.h>
+#include "mts_ros_crtk_atracsys_bridge.h"
 
 #include <QApplication>
 #include <QMainWindow>
@@ -87,9 +87,16 @@ int main(int argc, char * argv[])
     componentManager->AddComponent(tracker);
 
     // ROS CRTK bridge
-    mts_ros_crtk_bridge_provided * crtk_bridge
-        = new mts_ros_crtk_bridge_provided("atracsys_crtk_bridge", &rosNodeHandle);
+    mts_ros_crtk_atracsys_bridge * crtk_bridge
+        = new mts_ros_crtk_atracsys_bridge("atracsys_crtk_bridge", &rosNodeHandle);
     crtk_bridge->add_factory_source("atracsys", "Controller", rosPeriod, tfPeriod);
+
+    auto num_tools = tracker->GetNumberOfTools();
+    for (size_t i = 0; i < num_tools; ++i) {
+        crtk_bridge->bridge_tool_error("atracsys",tracker->GetToolName(i), rosPeriod, tfPeriod);
+    }
+    // crtk_bridge->bridge("atracsys", "Controller", rosPeriod, tfPeriod)
+
     componentManager->AddComponent(crtk_bridge);
     crtk_bridge->Connect();
 

--- a/ros/src/mts_ros_crtk_atracsys_bridge.cpp
+++ b/ros/src/mts_ros_crtk_atracsys_bridge.cpp
@@ -1,0 +1,92 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-    */
+/* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
+
+/*
+  Author(s):  Anton Deguet
+  Created on: 2017-11-28
+
+  (C) Copyright 2017-2020 Johns Hopkins University (JHU), All Rights Reserved.
+
+--- begin cisst license - do not edit ---
+
+This software is provided "as is" under an open source license, with
+no warranty.  The complete license can be found in license.txt and
+http://www.cisst.org/cisst/license.txt.
+
+--- end cisst license ---
+*/
+
+// system include
+#include <iostream>
+
+// cisst
+#include "mts_ros_crtk_atracsys_bridge.h"
+#include <cisst_ros_bridge/mtsROSBridge.h>
+#include <std_msgs/Float64.h>
+
+CMN_IMPLEMENT_SERVICES(mts_ros_crtk_atracsys_bridge);
+
+
+void mts_ros_crtk_atracsys_bridge::bridge(const std::string & _component_name,
+                                     const std::string & _interface_name,
+                                     const double _publish_period_in_seconds,
+                                     const double _tf_period_in_seconds)
+{
+    // clean ROS namespace
+    std::string _clean_namespace = _component_name;
+    cisst_ros_crtk::clean_namespace(_clean_namespace);
+
+    // create factory to bridge tool as they get created
+    this->add_factory_source(_component_name,
+                             _interface_name,
+                             _publish_period_in_seconds,
+                             _tf_period_in_seconds);
+
+    // controller specific topics, some might be CRTK compliant
+    this->bridge_interface_provided(_component_name,
+                                    _interface_name,
+                                    _clean_namespace,
+                                    _publish_period_in_seconds,
+                                    _tf_period_in_seconds);
+
+    // non CRTK topics
+    // add trailing / for clean namespace
+    if (!_clean_namespace.empty()) {
+        _clean_namespace.append("/");
+    }
+    // required interfaces specific to this component to bridge
+    const std::string _required_interface_name = _component_name + "_using_" + _interface_name;
+
+    // connections
+    m_connections.Add(m_subscribers_bridge->GetName(), _required_interface_name,
+                      _component_name, _interface_name);
+    m_connections.Add(m_events_bridge->GetName(), _required_interface_name,
+                      _component_name, _interface_name);
+}
+
+void mts_ros_crtk_atracsys_bridge::bridge_tool_error(const std::string & _component_name,
+                                     const std::string & _interface_name,
+                                     const double _publish_period_in_seconds,
+                                     const double _tf_period_in_seconds)
+{
+    std::string _clean_namespace = _component_name;
+    cisst_ros_crtk::clean_namespace(_clean_namespace);
+
+
+    
+    // add trailing / for clean namespace
+    if (!_clean_namespace.empty()) {
+        _clean_namespace.append("/");
+    }
+    // required interfaces specific to this component to bridge
+    const std::string _required_interface_name = _component_name + "_using_" + _interface_name;
+
+    // non CRTK topics
+    m_subscribers_bridge->AddPublisherFromCommandRead<double, std_msgs::Float64>
+        (_required_interface_name, "registration_error", _component_name + "/" + _interface_name + "/registration_error");
+
+    m_connections.Add(m_subscribers_bridge->GetName(), _required_interface_name,
+                      _component_name, _interface_name);
+
+    
+}

--- a/ros/src/mts_ros_crtk_atracsys_bridge.h
+++ b/ros/src/mts_ros_crtk_atracsys_bridge.h
@@ -1,0 +1,51 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-    */
+/* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
+
+/*
+  Author(s):  Anton Deguet
+  Created on: 2017-11-28
+
+  (C) Copyright 2017-2020 Johns Hopkins University (JHU), All Rights Reserved.
+
+--- begin cisst license - do not edit ---
+
+This software is provided "as is" under an open source license, with
+no warranty.  The complete license can be found in license.txt and
+http://www.cisst.org/cisst/license.txt.
+
+--- end cisst license ---
+*/
+
+#ifndef _mts_ros_crtk_atracsys_bridge_h
+#define _mts_ros_crtk_atracsys_bridge_h
+
+#include <cisst_ros_crtk/mts_ros_crtk_bridge.h>
+
+class mts_ros_crtk_atracsys_bridge: public mts_ros_crtk_bridge
+{
+    CMN_DECLARE_SERVICES(CMN_NO_DYNAMIC_CREATION, CMN_LOG_ALLOW_DEFAULT);
+
+ public:
+    inline mts_ros_crtk_atracsys_bridge(const std::string & _component_name,
+                                   ros::NodeHandle * _node_handle,
+                                   const double _period_in_seconds = 5.0 * cmn_ms):
+        mts_ros_crtk_bridge(_component_name, _node_handle, _period_in_seconds)
+    {}
+
+    inline ~mts_ros_crtk_atracsys_bridge() {}
+
+    /*! Everything needed to bridge the sawatracsysTracker component */
+    void bridge(const std::string & _component_name,
+                const std::string & _interface_name,
+                const double _publish_period_in_seconds,
+                const double _tf_period_in_seconds);
+
+    void bridge_tool_error(const std::string & _component_name,
+                                     const std::string & _interface_name,
+                                     const double _publish_period_in_seconds,
+                                     const double _tf_period_in_seconds);
+};
+
+CMN_DECLARE_SERVICES_INSTANTIATION(mts_ros_crtk_atracsys_bridge);
+
+#endif // _mts_ros_crtk_atracsys_bridge_h


### PR DESCRIPTION
Hi Anton, I quickly threw this implementation together to help expose the registration error (implemented per-tool in the cisst mts code already) to a ROS topic for a colleague in the lab. I think it might be useful for others also!

Admittedly, I think it could be done much more efficiently (maybe via the factory already set up for each tool?), but I opted to take a leaf out of the sawNDITracker implementation as I have done in other cases and create a derived crtk_cisst_ros_bridge for this application that also achieves this. 

The "registration_error" is just a double, but it exists for each tool, which I had trouble bridging directly as the previous bridge utilized a factory. I hope this implementation could be useful, please feel free to adjust it to fit the rest of the design more closely if needed!