### PR TITLE
Stereo processing for spryTrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,33 @@ If you also want ROS topics corresponding to the tracked tools, try:
 rosrun atracsys atracsys -j config003.json
 ```
 
+### Configuration file format
+
+The JSON configuration files consists of a list of tools to track, and optionally configuration for the stereo image processing (for the spryTrack RGB devices). The `definition-path` property can optionally be set to a list of file paths to search tool definitions for --- by default, the search path for tool definition files is the current working directory, and the directory containing the configuration file.
+
+```json
+{
+  definition-path: ["additional tool definition search path", "another search path"],
+  tools: [
+    {
+      {
+        "name": "Marker3", // tool name, used in GUI display and in ROS topics for that tool
+        // provided tool definition as either json or ini
+        "json-file": "geometry003.json", // json tool definition file
+        "ini-file": "geometry003.ini" // or ini tool definition file
+      },
+    }
+  ],
+  stereo: {
+    "video": true, // (default false) provide rectified video streams
+    "depth": true, // (default false) compute 3D point cloud from stereo images
+    "filter_depth_map": true, // post-process depth map - improves quality at cost of some additional computation
+    "global_block_matching": true, // (default false) use (semi)global block matching algorithm instead of default local block matching
+    "num_dot_projectors": 3 // (default 0 if depth = false, 1 if depth = true) how many dot projector pairs to turn on - dot projectors add texture to images, increasing quality of stereo correspondence matching
+  }
+}
+```
+
 # Unable to find shared object file `libdevice64.so`
 
 When using ROS, we copy the SDK libraries in the ROS build tree so you shouldn't have to edit your LD_LIBRARY path.  If you still get some error messages re. missing libraries, you need to locate the libraries and edit your `LD_LIBRARY_PATH`.  Something like:
@@ -133,6 +160,14 @@ transform:
     w: -0.068462781014
 ---
 ```
+
+# Stereo processing
+
+For devices such as the spryTrack 300 RGB which provide RGB images and have dot projectors, stereo processing is provided to compute a dense 3D point cloud. This can be enabled via the configuration file as described above.
+
+Enabling the global block matching option may improve depth map quality, however it will often slow down processing significantly
+
+Enabling the depth map filtering algorithm will perform left-right consisteny checks to reject bad readings, and apply an edge-aware filtering algorithm to help reduce noise. This increases the computational cost of the stereo processing, particularly when the global block matching is enabled.
 
 # Known issues, features to add
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ The JSON configuration files consists of a list of tools to track, and optionall
     "color_pointcloud": false, // (default false) add color to pointcloud output - enabling can slow down ROS publishing quite a bit
     "filter_depth_map": false, // post-process depth map - can remove some noise, but may over-smooth regions
     "global_block_matching": false, // (default false) use (semi)global block matching algorithm instead of default local block matching
-    "num_dot_projectors": 3 // (default 0 if depth = false, 1 if depth = true) how many dot projector pairs to turn on - dot projectors add texture to images, increasing quality of stereo correspondence matching. Valid range may depend on device model, but is 0 to 3 inclusive for the spryTrack 300.
+    "num_dot_projectors": 3, // (default 0 if depth = false, 1 if depth = true) how many dot projector pairs to turn on - dot projectors add texture to images, increasing quality of stereo correspondence matching. Valid range may depend on device model, but is 0 to 3 inclusive for the spryTrack 300.
+    "min_depth": 1.0 // (default 1.35 meters) minimum depth (from camera) that will be measured. Due to stereo geometry, measuring closer distances results in reduced viewport.
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ The JSON configuration files consists of a list of tools to track, and optionall
   stereo: {
     "video": true, // (default false) provide rectified video streams
     "depth": true, // (default false) compute 3D point cloud from stereo images
-    "filter_depth_map": true, // post-process depth map - improves quality at cost of some additional computation
-    "global_block_matching": true, // (default false) use (semi)global block matching algorithm instead of default local block matching
-    "num_dot_projectors": 3 // (default 0 if depth = false, 1 if depth = true) how many dot projector pairs to turn on - dot projectors add texture to images, increasing quality of stereo correspondence matching
+    "color_pointcloud": false, // (default false) add color to pointcloud output - enabling can slow down ROS publishing quite a bit
+    "filter_depth_map": false, // post-process depth map - can remove some noise, but may over-smooth regions
+    "global_block_matching": false, // (default false) use (semi)global block matching algorithm instead of default local block matching
+    "num_dot_projectors": 3 // (default 0 if depth = false, 1 if depth = true) how many dot projector pairs to turn on - dot projectors add texture to images, increasing quality of stereo correspondence matching. Valid range may depend on device model, but is 0 to 3 inclusive for the spryTrack 300.
   }
 }
 ```
@@ -163,11 +164,15 @@ transform:
 
 # Stereo processing
 
-For devices such as the spryTrack 300 RGB which provide RGB images and have dot projectors, stereo processing is provided to compute a dense 3D point cloud. This can be enabled via the configuration file as described above.
+For devices such as the spryTrack 300 RGB which provide RGB images and have dot projectors, stereo processing is provided to compute a dense 3D point cloud. This can be enabled via the configuration file as described above, which at minimum requires adding `"stereo": { "depth": true }` to the configuration file.
 
-Enabling the global block matching option may improve depth map quality, however it will often slow down processing significantly
+A good default configuration is to enabled depth map filtering, but keep global block matching disabled, this should provide a fairly good point cloud. The colored point cloud option can be enabled to make it easier to visualize the point cloud, but should otherwise be disabled since it degrades performance.
 
-Enabling the depth map filtering algorithm will perform left-right consisteny checks to reject bad readings, and apply an edge-aware filtering algorithm to help reduce noise. This increases the computational cost of the stereo processing, particularly when the global block matching is enabled.
+Enabling the global block matching option may improve depth map quality, however it will often slow down processing significantly.
+
+Enabling the depth map filtering algorithm will perform left-right consisteny checks to reject bad readings, and apply an edge-aware filtering algorithm to help reduce noise. This may help smooth the pointcloud in some situations, but the smoothing can also be detrimental so this option is disabled by default. Enabling this option will somewhat increase the computational cost of the stereo processing, particularly when the global block matching is enabled.
+
+Enabling the depth map filtering may also help to fill in holes in the point cloud.
 
 # Known issues, features to add
 

--- a/core/components/CMakeLists.txt
+++ b/core/components/CMakeLists.txt
@@ -48,6 +48,8 @@ if (cisst_FOUND_AS_REQUIRED)
     endif ()
   endif ()
 
+  find_package(OpenCV REQUIRED)
+
   # catkin/ROS paths
   cisst_set_output_path ()
 
@@ -89,12 +91,15 @@ if (cisst_FOUND_AS_REQUIRED)
     add_library (sawAtracsysFusionTrack ${IS_SHARED}
       ${sawAtracsysFusionTrack_HEADER_DIR}/sawAtracsysFusionTrackExport.h
       code/mtsAtracsysFusionTrack.cpp
-      ${sawAtracsysFusionTrack_HEADER_DIR}/mtsAtracsysFusionTrack.h)
+      code/mtsAtracsysStereo.cpp
+      ${sawAtracsysFusionTrack_HEADER_DIR}/mtsAtracsysFusionTrack.h
+      ${sawAtracsysFusionTrack_HEADER_DIR}/mtsAtracsysStereo.h)
     set_target_properties (sawAtracsysFusionTrack PROPERTIES
       VERSION ${sawAtracsysFusionTrack_VERSION}
       FOLDER "sawAtracsysFusionTrack")
     cisst_target_link_libraries (sawAtracsysFusionTrack ${REQUIRED_CISST_LIBRARIES})
     target_link_libraries (sawAtracsysFusionTrack ${AtracsysSDK_LIBRARIES})
+    target_link_libraries (sawAtracsysFusionTrack ${OpenCV_LIBS})
 
     configure_file (
       "${sawAtracsysFusionTrack_SOURCE_DIR}/code/sawAtracsysFusionTrackConfig.h.in"

--- a/core/components/CMakeLists.txt
+++ b/core/components/CMakeLists.txt
@@ -48,8 +48,6 @@ if (cisst_FOUND_AS_REQUIRED)
     endif ()
   endif ()
 
-  find_package(OpenCV REQUIRED)
-
   # catkin/ROS paths
   cisst_set_output_path ()
 
@@ -88,17 +86,31 @@ if (cisst_FOUND_AS_REQUIRED)
 
     cisst_add_config_files (sawAtracsysFusionTrack)
 
-    add_library (sawAtracsysFusionTrack ${IS_SHARED}
+    set (sawAtracsysFusionTrack_SOURCES
       ${sawAtracsysFusionTrack_HEADER_DIR}/sawAtracsysFusionTrackExport.h
       code/mtsAtracsysFusionTrack.cpp
-      code/mtsAtracsysStereo.cpp
       ${sawAtracsysFusionTrack_HEADER_DIR}/mtsAtracsysFusionTrack.h
-      ${sawAtracsysFusionTrack_HEADER_DIR}/mtsAtracsysStereo.h)
+    )
+
+    find_package(OpenCV)
+    if (OpenCV_FOUND)
+      set (sawAtracsysFusionTrack_SOURCES ${sawAtracsysFusionTrack_SOURCES}
+        code/mtsAtracsysStereo.cpp
+        ${sawAtracsysFusionTrack_HEADER_DIR}/mtsAtracsysStereo.h
+      )
+    endif (OpenCV_FOUND)
+
+    add_library (sawAtracsysFusionTrack ${IS_SHARED} ${sawAtracsysFusionTrack_SOURCES})
     set_target_properties (sawAtracsysFusionTrack PROPERTIES
       VERSION ${sawAtracsysFusionTrack_VERSION}
       FOLDER "sawAtracsysFusionTrack")
     cisst_target_link_libraries (sawAtracsysFusionTrack ${REQUIRED_CISST_LIBRARIES})
     target_link_libraries (sawAtracsysFusionTrack ${AtracsysSDK_LIBRARIES})
+
+    if (OpenCV_FOUND)
+      target_link_libraries (sawAtracsysFusionTrack ${OpenCV_LIBS})
+    endif (OpenCV_FOUND)
+
     target_link_libraries (sawAtracsysFusionTrack ${OpenCV_LIBS})
 
     configure_file (

--- a/core/components/code/mtsAtracsysFusionTrack.cpp
+++ b/core/components/code/mtsAtracsysFusionTrack.cpp
@@ -683,10 +683,7 @@ void mtsAtracsysFusionTrack::Configure(const std::string & filename)
 
 void mtsAtracsysFusionTrack::Startup(void)
 {
-    // trigger event so connected component can bridge crtk provided interface as needed
     m_configuration_state_table.Start();
-    m_crtk_interfaces_provided.push_back(mtsDescriptionInterfaceFullName("localhost", this->Name, "Controller"));
-    m_crtk_interfaces_provided_updated();
 
     // reports system found
     m_controller_interface->SendStatus(this->GetName() + ": found device SN " + std::to_string(m_internals->m_sn));
@@ -701,6 +698,8 @@ void mtsAtracsysFusionTrack::Startup(void)
     m_right_camera_info.Valid() = ok;
 
     m_configuration_state_table.Advance();
+
+    m_crtk_interfaces_provided_updated();
 }
 
 

--- a/core/components/code/mtsAtracsysFusionTrack.cpp
+++ b/core/components/code/mtsAtracsysFusionTrack.cpp
@@ -267,7 +267,7 @@ public:
         }
 
         if (m_sn == 0) {
-            CMN_LOG_INIT_ERROR << "Configure: no Atracsys device connected" << std::endl;
+            CMN_LOG_INIT_ERROR << "Configure: no Atracsys devices found" << std::endl;
             return false;
         }
 
@@ -617,8 +617,9 @@ void mtsAtracsysFusionTrack::Configure(const std::string & filename)
 
     bool ok = m_internals->Initialize();
     if (!ok) {
-        CMN_LOG_INIT_ERROR << "Configure: no device connected ("
+        CMN_LOG_INIT_ERROR << "Configure: failed to initialize device ("
                                  << this->GetName() << ")" << std::endl;
+        return;
     }
 
     CMN_LOG_CLASS_INIT_VERBOSE << "Configure: found device SN " << m_internals->m_sn << std::endl;
@@ -1100,15 +1101,19 @@ void mtsAtracsysFusionTrack::ProcessStrayMarkers()
     // ---- 3D Fiducials, aka stray markers ---
     switch (m_internals->m_frame_query->threeDFiducialsStat) {
     case FTK_QS_NS::QS_WAR_SKIPPED:
-        CMN_LOG_CLASS_RUN_ERROR << "Run: 3D fiducials fields not written" << std::endl;
+        CMN_LOG_CLASS_RUN_ERROR << "Stray markers: 3D fiducials fields not written" << std::endl;
         return;
     case FTK_QS_NS::QS_ERR_INVALID_RESERVED_SIZE:
-        CMN_LOG_CLASS_RUN_ERROR << "Run: frame.threeDFiducialsVersionSize is invalid" << std::endl;
+        CMN_LOG_CLASS_RUN_ERROR << "Stray markers: frame.threeDFiducialsVersionSize must be multiple of fiducial type size" << std::endl;
         return;
+    case FTK_QS_NS::QS_ERR_OVERFLOW:
+        CMN_LOG_CLASS_RUN_ERROR << "Stray markers: too many stray markers detected --- try covering metallic/reflective surfaces" << std::endl;
+        break;
     case FTK_QS_NS::QS_OK:
         break;
     default:
-        CMN_LOG_CLASS_RUN_ERROR << "Run: invalid status" << std::endl;
+        int status = static_cast<int>(m_internals->m_frame_query->threeDFiducialsStat);
+        CMN_LOG_CLASS_RUN_ERROR << "Run: invalid status " << status << std::endl;
         break;
     }
 

--- a/core/components/code/mtsAtracsysStereo.cpp
+++ b/core/components/code/mtsAtracsysStereo.cpp
@@ -65,7 +65,7 @@ void mtsAtracsysStereo::Init(void)
     m_video_enabled = false;
     m_depth_enabled = false;
 
-    m_local_block_matching = false;
+    m_global_block_matching = false;
     m_filter_depth_map = false;
 }
 
@@ -74,6 +74,8 @@ void mtsAtracsysStereo::InitStereoPipeline()
     m_pipline_initialized = false;
 
     mtsExecutionResult result;
+
+    /// Retrieve stereo calibration
 
     result = m_get_left_camera_info(m_left_camera_info);
     if (!result.IsOK() || !m_left_camera_info.Valid()) {
@@ -97,6 +99,8 @@ void mtsAtracsysStereo::InitStereoPipeline()
         return;
     }
 
+    /// Convert to OpenCV calibration format
+
     cv::Mat left_intrinsic = cv::Mat(3, 3, CV_64F, m_left_camera_info.Intrinsic().Pointer());
     cv::Mat right_intrinsic = cv::Mat(3, 3, CV_64F, m_right_camera_info.Intrinsic().Pointer());
     cv::Mat left_distortion = cv::Mat(5, 1, CV_64F, m_left_camera_info.DistortionParameters().Pointer());
@@ -110,6 +114,8 @@ void mtsAtracsysStereo::InitStereoPipeline()
     // stereo rectification output matrices
     cv::Mat left_rect, right_rect;
     cv::Mat left_proj, right_proj;
+
+    // Compute rectification maps and projection matrices
 
     cv::stereoRectify(
         left_intrinsic, left_distortion,
@@ -135,37 +141,44 @@ void mtsAtracsysStereo::InitStereoPipeline()
         m_right_undistort_map_x, m_right_undistort_map_y
     );
 
+    /// Convert results to CISST data types
+
     std::copy(left_rect.begin<double>(), left_rect.end<double>(), m_left_camera_info.Rectification().begin());
     std::copy(right_rect.begin<double>(), right_rect.end<double>(), m_right_camera_info.Rectification().begin());
     std::copy(left_proj.begin<double>(), left_proj.end<double>(), m_left_camera_info.Projection().begin());
     std::copy(right_proj.begin<double>(), right_proj.end<double>(), m_right_camera_info.Projection().begin());
 
-    if (m_local_block_matching) {
-        m_left_stereo_matcher = cv::StereoBM::create(384, 7);
+    /// Create stereo matcher(s) and depth map filters
+
+    if (!m_global_block_matching) {
+        m_left_stereo_matcher = cv::StereoBM::create(784, 7);
     } else {
-        m_left_stereo_matcher = cv::StereoSGBM::create(0, 384, 7);
+        m_left_stereo_matcher = cv::StereoSGBM::create(0, 784, 7);
     }
 
     m_right_stereo_matcher = cv::ximgproc::createRightMatcher(m_left_stereo_matcher);
     m_wls_filter = cv::ximgproc::createDisparityWLSFilter(m_left_stereo_matcher);
     m_wls_filter->setLambda(8000.0);
-    m_wls_filter->setSigmaColor(1.0);
+    m_wls_filter->setSigmaColor(1.4);
 
     m_pipline_initialized = true;
 }
 
 void mtsAtracsysStereo::Rectify(prmImageFrame& raw, cv::Mat& rectified_mat, prmImageFrame& rectified, const cv::Mat& undistort_x, const cv::Mat& undistort_y)
 {
+    /// De-bayer image
     cv::Mat raw_bayer = cv::Mat(raw.Height(), raw.Width(), CV_8U, raw.Data().Pointer());
     cv::Mat raw_rgb;
     cv::cvtColor(raw_bayer, raw_rgb, cv::COLOR_BayerGR2BGR_EA);
 
+    // Rectify
     cv::remap(raw_rgb, rectified_mat, undistort_x, undistort_y, cv::INTER_LINEAR);
 
     rectified.Width() = rectified_mat.cols;
     rectified.Height() = rectified_mat.rows;
     rectified.Channels() = rectified_mat.channels();
 
+    // Convert to prmImageFrame
     size_t size = rectified_mat.cols * rectified_mat.rows * rectified_mat.channels();
     rectified.Data().resize(size);
     std::copy(rectified_mat.data, rectified_mat.data + size, rectified.Data().begin());
@@ -173,13 +186,17 @@ void mtsAtracsysStereo::Rectify(prmImageFrame& raw, cv::Mat& rectified_mat, prmI
 
 void mtsAtracsysStereo::ComputeDepth()
 {
+    // Convert to gray-scale
     cv::Mat left_gray, right_gray;
     cv::cvtColor(m_left_image_mat, left_gray, cv::COLOR_RGB2GRAY);
     cv::cvtColor(m_right_image_mat, right_gray, cv::COLOR_RGB2GRAY);
 
+    // Compute left-to-right stereo correspondence
     cv::Mat left_disparity, right_disparity;
     m_left_stereo_matcher->compute(left_gray, right_gray, left_disparity);
 
+    // If filtering is enabled, compute the right-to-left correspondence
+    // and run WLS filter
     cv::Mat disparity;
     if (m_filter_depth_map) {
         m_right_stereo_matcher->compute(right_gray, left_gray, right_disparity);
@@ -188,8 +205,10 @@ void mtsAtracsysStereo::ComputeDepth()
         disparity = left_disparity;
     }
     
+    // Disparity maps use fixed-point format, need to rescale by 1/16 to convert to floating point
     disparity.convertTo(disparity, CV_32F, 1.0f/16.0, 0.0f);
 
+    // Use stereo calibration to convert from disparity to depth values
     cv::Mat depth;
     cv::reprojectImageTo3D(disparity, depth, disparity_to_depth, true, -1);
 
@@ -220,7 +239,6 @@ void mtsAtracsysStereo::Configure(const std::string & filename)
         exit(EXIT_FAILURE);
     }
 
-    // read JSON file passed as param, see configAtracsysFusionTrack.json for an example
     std::ifstream jsonStream;
     jsonStream.open(config_fullname.c_str());
 
@@ -239,11 +257,12 @@ void mtsAtracsysStereo::Configure(const std::string & filename)
         m_video_enabled = stereo.isMember("video") && video.isBool() && video.asBool();
         const Json::Value depth = stereo["depth"];
         m_depth_enabled = stereo.isMember("depth") && depth.isBool() && depth.asBool();
+
         // video processing is required for depth map computation
         m_video_enabled = m_depth_enabled || m_video_enabled;
 
-        const Json::Value local_bm = stereo["local_block_matching"];
-        m_local_block_matching = stereo.isMember("local_block_matching") && local_bm.isBool() && local_bm.asBool();
+        const Json::Value global_bm = stereo["global_block_matching"];
+        m_global_block_matching = stereo.isMember("global_block_matching") && global_bm.isBool() && global_bm.asBool();
 
         const Json::Value filter_depth = stereo["filter_depth_map"];
         m_filter_depth_map = stereo.isMember("filter_depth_map") && filter_depth.isBool() && filter_depth.asBool();

--- a/core/components/code/mtsAtracsysStereo.cpp
+++ b/core/components/code/mtsAtracsysStereo.cpp
@@ -1,0 +1,296 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-    */
+/* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
+
+/*
+  Author(s):  Anton Deguet
+  Created on: 2014-07-17
+
+  (C) Copyright 2014-2024 Johns Hopkins University (JHU), All Rights Reserved.
+
+--- begin cisst license - do not edit ---
+
+This software is provided "as is" under an open source license, with
+no warranty.  The complete license can be found in license.txt and
+http://www.cisst.org/cisst/license.txt.
+
+--- end cisst license ---
+*/
+
+#include <sawAtracsysFusionTrack/mtsAtracsysStereo.h>
+#include <sawAtracsysFusionTrack/sawAtracsysFusionTrackConfig.h>
+
+#include <ftkInterface.h>
+
+#include <cisstCommon/cmnPath.h>
+#include <cisstMultiTask/mtsInterfaceProvided.h>
+#include <cisstMultiTask/mtsInterfaceRequired.h>
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/stereo.hpp>
+#include <opencv2/calib3d.hpp>
+
+
+CMN_IMPLEMENT_SERVICES_DERIVED_ONEARG(mtsAtracsysStereo, mtsTaskContinuous, mtsTaskContinuousConstructorArg);
+
+void mtsAtracsysStereo::Init(void)
+{
+    StateTable.AddData(m_left_image, "left_image");
+    StateTable.AddData(m_right_image, "right_image");
+    StateTable.AddData(m_left_camera_info, "left_camera_info");
+    StateTable.AddData(m_right_camera_info, "right_camera_info");
+    StateTable.AddData(m_depth, "depth");
+
+    m_stereo_interface = AddInterfaceProvided("stereo");
+    if (m_stereo_interface) {
+        m_stereo_interface->AddCommandReadState(StateTable, m_left_image, "left/image_rect_color");
+        m_stereo_interface->AddCommandReadState(StateTable, m_left_camera_info, "left/camera_info");
+        m_stereo_interface->AddCommandReadState(StateTable, m_right_image, "right/image_rect_color");
+        m_stereo_interface->AddCommandReadState(StateTable, m_right_camera_info, "right/camera_info");
+        m_stereo_interface->AddCommandReadState(StateTable, m_depth, "depth");
+
+        m_stereo_interface->AddCommandReadState(StateTable, StateTable.PeriodStats, "period_statistics");
+    }
+
+    m_stereo_raw_interface = AddInterfaceRequired("StereoRaw");
+    if (m_stereo_raw_interface) {
+        m_stereo_raw_interface->AddFunction("left/image_raw", m_get_left_image_raw);
+        m_stereo_raw_interface->AddFunction("right/image_raw", m_get_right_image_raw);
+        m_stereo_raw_interface->AddFunction("left/camera_info", m_get_left_camera_info);
+        m_stereo_raw_interface->AddFunction("right/camera_info", m_get_right_camera_info);
+        m_stereo_raw_interface->AddFunction("camera_rotation", m_get_camera_rotation);
+        m_stereo_raw_interface->AddFunction("camera_translation", m_get_camera_translation);
+    }
+
+    m_pipline_initialized = false;
+    m_video_enabled = false;
+    m_depth_enabled = false;
+
+    m_local_block_matching = false;
+    m_filter_depth_map = false;
+}
+
+void mtsAtracsysStereo::InitStereoPipeline()
+{
+    m_pipline_initialized = false;
+
+    mtsExecutionResult result;
+
+    result = m_get_left_camera_info(m_left_camera_info);
+    if (!result.IsOK() || !m_left_camera_info.Valid()) {
+        return;
+    }
+
+    result = m_get_right_camera_info(m_right_camera_info);
+    if (!result.IsOK() || !m_right_camera_info.Valid()) {
+        return;
+    }
+
+    vct3 rotation, translation;
+
+    result = m_get_camera_rotation(rotation);
+    if (!result.IsOK()) {
+        return;
+    }
+
+    result = m_get_camera_translation(translation);
+    if (!result.IsOK()) {
+        return;
+    }
+
+    cv::Mat left_intrinsic = cv::Mat(3, 3, CV_64F, m_left_camera_info.Intrinsic().Pointer());
+    cv::Mat right_intrinsic = cv::Mat(3, 3, CV_64F, m_right_camera_info.Intrinsic().Pointer());
+    cv::Mat left_distortion = cv::Mat(5, 1, CV_64F, m_left_camera_info.DistortionParameters().Pointer());
+    cv::Mat right_distortion = cv::Mat(5, 1, CV_64F, m_right_camera_info.DistortionParameters().Pointer());
+
+    cv::Size original_image_size = cv::Size(m_left_camera_info.Width(), m_left_camera_info.Height());
+
+    cv::Mat R = cv::Mat(3, 1, CV_64F, rotation.Pointer());
+    cv::Mat T = cv::Mat(3, 1, CV_64F, translation.Pointer());
+
+    // stereo rectification output matrices
+    cv::Mat left_rect, right_rect;
+    cv::Mat left_proj, right_proj;
+
+    cv::stereoRectify(
+        left_intrinsic, left_distortion,
+        right_intrinsic, right_distortion,
+        original_image_size, R, T,
+        left_rect, right_rect, left_proj, right_proj,
+        disparity_to_depth
+    );
+
+    cv::initUndistortRectifyMap(
+        left_intrinsic, left_distortion,
+        left_rect, left_proj,
+        original_image_size,
+        CV_32FC(1),
+        m_left_undistort_map_x, m_left_undistort_map_y
+    );
+
+    cv::initUndistortRectifyMap(
+        right_intrinsic, right_distortion,
+        right_rect, right_proj,
+        original_image_size,
+        CV_32FC(1),
+        m_right_undistort_map_x, m_right_undistort_map_y
+    );
+
+    std::copy(left_rect.begin<double>(), left_rect.end<double>(), m_left_camera_info.Rectification().begin());
+    std::copy(right_rect.begin<double>(), right_rect.end<double>(), m_right_camera_info.Rectification().begin());
+    std::copy(left_proj.begin<double>(), left_proj.end<double>(), m_left_camera_info.Projection().begin());
+    std::copy(right_proj.begin<double>(), right_proj.end<double>(), m_right_camera_info.Projection().begin());
+
+    if (m_local_block_matching) {
+        m_left_stereo_matcher = cv::StereoBM::create(384, 7);
+    } else {
+        m_left_stereo_matcher = cv::StereoSGBM::create(0, 384, 7);
+    }
+
+    m_right_stereo_matcher = cv::ximgproc::createRightMatcher(m_left_stereo_matcher);
+    m_wls_filter = cv::ximgproc::createDisparityWLSFilter(m_left_stereo_matcher);
+    m_wls_filter->setLambda(8000.0);
+    m_wls_filter->setSigmaColor(1.0);
+
+    m_pipline_initialized = true;
+}
+
+void mtsAtracsysStereo::Rectify(prmImageFrame& raw, cv::Mat& rectified_mat, prmImageFrame& rectified, const cv::Mat& undistort_x, const cv::Mat& undistort_y)
+{
+    cv::Mat raw_bayer = cv::Mat(raw.Height(), raw.Width(), CV_8U, raw.Data().Pointer());
+    cv::Mat raw_rgb;
+    cv::cvtColor(raw_bayer, raw_rgb, cv::COLOR_BayerGR2BGR_EA);
+
+    cv::remap(raw_rgb, rectified_mat, undistort_x, undistort_y, cv::INTER_LINEAR);
+
+    rectified.Width() = rectified_mat.cols;
+    rectified.Height() = rectified_mat.rows;
+    rectified.Channels() = rectified_mat.channels();
+
+    size_t size = rectified_mat.cols * rectified_mat.rows * rectified_mat.channels();
+    rectified.Data().resize(size);
+    std::copy(rectified_mat.data, rectified_mat.data + size, rectified.Data().begin());
+}
+
+void mtsAtracsysStereo::ComputeDepth()
+{
+    cv::Mat left_gray, right_gray;
+    cv::cvtColor(m_left_image_mat, left_gray, cv::COLOR_RGB2GRAY);
+    cv::cvtColor(m_right_image_mat, right_gray, cv::COLOR_RGB2GRAY);
+
+    cv::Mat left_disparity, right_disparity;
+    m_left_stereo_matcher->compute(left_gray, right_gray, left_disparity);
+
+    cv::Mat disparity;
+    if (m_filter_depth_map) {
+        m_right_stereo_matcher->compute(right_gray, left_gray, right_disparity);
+        m_wls_filter->filter(left_disparity, m_left_image_mat, disparity, right_disparity, cv::Rect(), m_right_image_mat);
+    } else {
+        disparity = left_disparity;
+    }
+    
+    disparity.convertTo(disparity, CV_32F, 1.0f/16.0, 0.0f);
+
+    cv::Mat depth;
+    cv::reprojectImageTo3D(disparity, depth, disparity_to_depth, true, -1);
+
+    m_depth.Width() = depth.cols;
+    m_depth.Height() = depth.rows;
+
+    size_t size = depth.cols * depth.rows * depth.channels();
+
+    m_depth.Points().resize(size);
+    std::copy(reinterpret_cast<float*>(depth.data), reinterpret_cast<float*>(depth.data) + size, m_depth.Points().begin());
+
+    m_depth.Color().resize(m_left_image_mat.cols * m_left_image_mat.rows * m_left_image_mat.channels());
+    std::copy(m_left_image_mat.data, m_left_image_mat.data + size, m_depth.Color().begin());
+}
+
+void mtsAtracsysStereo::Configure(const std::string & filename)
+{
+    CMN_LOG_CLASS_INIT_VERBOSE << "Configure: using " << filename << std::endl;
+
+    cmnPath m_config_path;
+    m_config_path.Add(cmnPath::GetWorkingDirectory());
+    m_config_path.Add(std::string(sawAtracsysFusionTrack_SOURCE_DIR) + "/../share", cmnPath::TAIL);
+
+    std::string config_fullname = m_config_path.Find(filename);
+    if (!cmnPath::Exists(config_fullname)) {
+        CMN_LOG_CLASS_INIT_ERROR << "Configure: configuration file \"" << filename
+                                 << "\" not found in path (" << m_config_path << ")" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // read JSON file passed as param, see configAtracsysFusionTrack.json for an example
+    std::ifstream jsonStream;
+    jsonStream.open(config_fullname.c_str());
+
+    Json::Value jsonConfig;
+    Json::Reader jsonReader;
+    if (!jsonReader.parse(jsonStream, jsonConfig)) {
+        CMN_LOG_CLASS_INIT_ERROR << "Configure: failed to parse configuration" << std::endl
+                                 << jsonReader.getFormattedErrorMessages();
+        exit(EXIT_FAILURE);
+        return;
+    }
+
+    if (jsonConfig.isMember("stereo")) {
+        const Json::Value stereo = jsonConfig["stereo"];
+        const Json::Value video = stereo["video"];
+        m_video_enabled = stereo.isMember("video") && video.isBool() && video.asBool();
+        const Json::Value depth = stereo["depth"];
+        m_depth_enabled = stereo.isMember("depth") && depth.isBool() && depth.asBool();
+        // video processing is required for depth map computation
+        m_video_enabled = m_depth_enabled || m_video_enabled;
+
+        const Json::Value local_bm = stereo["local_block_matching"];
+        m_local_block_matching = stereo.isMember("local_block_matching") && local_bm.isBool() && local_bm.asBool();
+
+        const Json::Value filter_depth = stereo["filter_depth_map"];
+        m_filter_depth_map = stereo.isMember("filter_depth_map") && filter_depth.isBool() && filter_depth.asBool();
+    }
+}
+
+void mtsAtracsysStereo::Startup(void) { }
+
+void mtsAtracsysStereo::Run(void)
+{
+    // process mts commands
+    ProcessQueuedCommands();
+
+    if (!m_depth_enabled && !m_video_enabled) {
+        return;
+    }
+
+    if (!m_pipline_initialized) {
+        InitStereoPipeline();
+        return;
+    }
+
+    mtsExecutionResult result;
+    prmImageFrame left_raw, right_raw;
+
+    result = m_get_left_image_raw(left_raw);
+    if (!result.IsOK() || !left_raw.Valid()) {
+        return;
+    }
+
+    result = m_get_right_image_raw(right_raw);
+    if (!result.IsOK() || !right_raw.Valid()) {
+        return;
+    }
+
+    Rectify(left_raw, m_left_image_mat, m_left_image, m_left_undistort_map_x, m_left_undistort_map_y);
+    Rectify(right_raw, m_right_image_mat, m_right_image, m_right_undistort_map_x, m_right_undistort_map_y);
+    m_left_image.Valid() = true;
+    m_right_image.Valid() = true;
+
+    if (!m_depth_enabled) {
+        return;
+    }
+
+    ComputeDepth();
+    m_depth.Valid() = true;
+    m_depth.ReferenceFrame() = m_reference_frame;
+}
+
+void mtsAtracsysStereo::Cleanup() {}

--- a/core/components/include/sawAtracsysFusionTrack/mtsAtracsysFusionTrack.h
+++ b/core/components/include/sawAtracsysFusionTrack/mtsAtracsysFusionTrack.h
@@ -109,6 +109,9 @@ protected:
     void ProcessIRTrackingFrame();
     void ProcessRGBStereoFrame();
 
+    void ProcessTools();
+    void ProcessStrayMarkers();
+
     /*! Search path for configuration files */
     cmnPath m_path;
     

--- a/core/components/include/sawAtracsysFusionTrack/mtsAtracsysFusionTrack.h
+++ b/core/components/include/sawAtracsysFusionTrack/mtsAtracsysFusionTrack.h
@@ -22,6 +22,8 @@ http://www.cisst.org/cisst/license.txt.
 #include <cisstCommon/cmnPath.h>
 #include <cisstMultiTask/mtsTaskContinuous.h>
 #include <cisstParameterTypes/prmPositionCartesianArrayGet.h>
+#include <cisstParameterTypes/prmImageFrame.h>
+#include <cisstParameterTypes/prmCameraInfo.h>
 
 #include <json/json.h> // in order to read config file
 
@@ -102,6 +104,9 @@ protected:
     /*! Code called by all constructors. */
     void Init(void);
 
+    void ProcessIRTrackingFrame();
+    void ProcessRGBStereoFrame();
+
     /*! Search path for configuration files */
     cmnPath m_path;
     
@@ -110,6 +115,8 @@ protected:
 
     /*! Controller interface */
     mtsInterfaceProvided * m_controller_interface = nullptr;
+
+    mtsInterfaceProvided * m_stereo_raw_interface = nullptr;
     
     mtsAtracsysFusionTrackInternals * m_internals = nullptr;
     typedef std::map<std::string, mtsAtracsysFusionTrackTool *> ToolsType;
@@ -120,9 +127,15 @@ protected:
 
     prmPositionCartesianArrayGet m_measured_cp_array;
 
+    prmCameraInfo m_left_camera_info, m_right_camera_info;
+    vct3 m_camera_rotation, m_camera_translation;
+    prmImageFrame m_left_image_raw, m_right_image_raw;
+    int m_num_enabled_dot_projectors = 0;
+
     /*! CRTK related methods */
     mtsFunctionVoid m_crtk_interfaces_provided_updated;
     std::vector<mtsDescriptionInterfaceFullName> m_crtk_interfaces_provided;
+
 };
 
 CMN_DECLARE_SERVICES_INSTANTIATION(mtsAtracsysFusionTrack);

--- a/core/components/include/sawAtracsysFusionTrack/mtsAtracsysFusionTrack.h
+++ b/core/components/include/sawAtracsysFusionTrack/mtsAtracsysFusionTrack.h
@@ -99,6 +99,8 @@ class CISST_EXPORT mtsAtracsysFusionTrack: public mtsTaskContinuous
 
     std::string GetToolName(const size_t index) const;
 
+    bool HardwareInitialized() const;
+
 protected:
 
     /*! Code called by all constructors. */

--- a/core/components/include/sawAtracsysFusionTrack/mtsAtracsysStereo.h
+++ b/core/components/include/sawAtracsysFusionTrack/mtsAtracsysStereo.h
@@ -95,6 +95,7 @@ protected:
 
     bool m_global_block_matching;
     bool m_filter_depth_map;
+    double m_min_depth;
 
     cv::Mat m_left_undistort_map_x, m_left_undistort_map_y;
     cv::Mat m_right_undistort_map_x, m_right_undistort_map_y;

--- a/core/components/include/sawAtracsysFusionTrack/mtsAtracsysStereo.h
+++ b/core/components/include/sawAtracsysFusionTrack/mtsAtracsysStereo.h
@@ -1,0 +1,108 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-    */
+/* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
+
+/*
+  Author(s):  Brendan Burkhart
+  Created on: 2024-07-01
+
+  (C) Copyright 2024 Johns Hopkins University (JHU), All Rights Reserved.
+
+--- begin cisst license - do not edit ---
+
+This software is provided "as is" under an open source license, with
+no warranty.  The complete license can be found in license.txt and
+http://www.cisst.org/cisst/license.txt.
+
+--- end cisst license ---
+*/
+
+#ifndef _mtsAtracsysStereo_h
+#define _mtsAtracsysStereo_h
+
+#include <string>
+
+#include <cisstMultiTask/mtsTaskContinuous.h>
+#include <cisstParameterTypes/prmImageFrame.h>
+#include <cisstParameterTypes/prmCameraInfo.h>
+#include <cisstParameterTypes/prmDepthMap.h>
+
+#include <json/json.h>
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/stereo.hpp>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/ximgproc/disparity_filter.hpp>
+
+#include <sawAtracsysFusionTrack/sawAtracsysFusionTrackExport.h>  // always include last
+
+class CISST_EXPORT mtsAtracsysStereo: public mtsTaskContinuous
+{
+    CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION_ONEARG, CMN_LOG_ALLOW_DEFAULT);
+
+ public:
+    inline mtsAtracsysStereo(const std::string & componentName, std::string reference_frame):
+        mtsTaskContinuous(componentName, 100),
+        m_reference_frame(reference_frame) {
+        Init();
+    }
+
+    inline mtsAtracsysStereo(const mtsTaskContinuousConstructorArg & arg):
+        mtsTaskContinuous(arg),
+        m_reference_frame(GetName()) {
+        Init();
+    }
+
+    ~mtsAtracsysStereo(void) {};
+
+    void Configure(const std::string & filename = "") override;
+
+    void Startup(void) override;
+
+    void Run(void) override;
+
+    void Cleanup(void) override;
+
+protected:
+    void Init(void); // shared initialization by all constructors
+    void InitStereoPipeline(); // one-time pipeline resource initialization
+    void Rectify(prmImageFrame& raw, cv::Mat& rectified_mat, prmImageFrame& rectified, const cv::Mat& undistort_x, const cv::Mat& undistort_y);
+    void ComputeDepth();
+
+    std::string m_reference_frame;
+
+    mtsInterfaceProvided * m_stereo_interface = nullptr;
+    mtsInterfaceRequired * m_stereo_raw_interface = nullptr;
+
+    prmCameraInfo m_left_camera_info;
+    prmImageFrame m_left_image;
+    prmCameraInfo m_right_camera_info;
+    prmImageFrame m_right_image;
+    prmDepthMap m_depth;
+
+    mtsFunctionRead m_get_left_image_raw;
+    mtsFunctionRead m_get_right_image_raw;
+    mtsFunctionRead m_get_left_camera_info;
+    mtsFunctionRead m_get_right_camera_info;
+    mtsFunctionRead m_get_camera_rotation;
+    mtsFunctionRead m_get_camera_translation;
+
+    cv::Mat m_left_image_mat, m_right_image_mat;
+
+    bool m_pipline_initialized;
+    bool m_video_enabled;
+    bool m_depth_enabled;
+
+    bool m_local_block_matching;
+    bool m_filter_depth_map;
+
+    cv::Mat m_left_undistort_map_x, m_left_undistort_map_y;
+    cv::Mat m_right_undistort_map_x, m_right_undistort_map_y;
+    cv::Mat disparity_to_depth;
+
+    cv::Ptr<cv::StereoMatcher> m_left_stereo_matcher, m_right_stereo_matcher;
+    cv::Ptr<cv::ximgproc::DisparityWLSFilter> m_wls_filter;
+};
+
+CMN_DECLARE_SERVICES_INSTANTIATION(mtsAtracsysStereo);
+
+#endif  // _mtsAtracsysStereo_h

--- a/core/components/include/sawAtracsysFusionTrack/mtsAtracsysStereo.h
+++ b/core/components/include/sawAtracsysFusionTrack/mtsAtracsysStereo.h
@@ -91,6 +91,7 @@ protected:
     bool m_pipline_initialized;
     bool m_video_enabled;
     bool m_depth_enabled;
+    bool m_color_pointcloud;
 
     bool m_global_block_matching;
     bool m_filter_depth_map;

--- a/core/components/include/sawAtracsysFusionTrack/mtsAtracsysStereo.h
+++ b/core/components/include/sawAtracsysFusionTrack/mtsAtracsysStereo.h
@@ -92,7 +92,7 @@ protected:
     bool m_video_enabled;
     bool m_depth_enabled;
 
-    bool m_local_block_matching;
+    bool m_global_block_matching;
     bool m_filter_depth_map;
 
     cv::Mat m_left_undistort_map_x, m_left_undistort_map_y;

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -70,8 +70,6 @@ if (cisst_FOUND_AS_REQUIRED)
   # sawAtracsysFusionTrack has been compiled within cisst, we should find it automatically
   find_package (sawAtracsysFusionTrack 1.1.0)
 
-  find_package(OpenCV REQUIRED)
-
   if (sawAtracsysFusionTrack_FOUND)
 
     # sawAtracsysFusionTrack configuration
@@ -81,8 +79,14 @@ if (cisst_FOUND_AS_REQUIRED)
     add_executable (atracsys src/atracsys.cpp src/atracsys_bridge.cpp src/atracsys_bridge.h)
     target_link_libraries (atracsys
       ${sawAtracsysFusionTrack_LIBRARIES}
-      ${catkin_LIBRARIES}
-      ${OpenCV_LIBS})
+      ${catkin_LIBRARIES})
+
+    find_package(OpenCV)
+    if (OpenCV_FOUND)
+      target_link_libraries (atracsys ${OpenCV_LIBS})
+    endif (OpenCV_FOUND)
+    target_compile_definitions(atracsys PRIVATE OpenCV_AVAILABLE=${OpenCV_FOUND})
+
     cisst_target_link_libraries (atracsys ${REQUIRED_CISST_LIBRARIES})
 
     install (TARGETS atracsys

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -70,6 +70,8 @@ if (cisst_FOUND_AS_REQUIRED)
   # sawAtracsysFusionTrack has been compiled within cisst, we should find it automatically
   find_package (sawAtracsysFusionTrack 1.1.0)
 
+  find_package(OpenCV REQUIRED)
+
   if (sawAtracsysFusionTrack_FOUND)
 
     # sawAtracsysFusionTrack configuration
@@ -79,7 +81,8 @@ if (cisst_FOUND_AS_REQUIRED)
     add_executable (atracsys src/atracsys.cpp src/mts_ros_crtk_atracsys_bridge.cpp src/mts_ros_crtk_atracsys_bridge.h)
     target_link_libraries (atracsys
       ${sawAtracsysFusionTrack_LIBRARIES}
-      ${catkin_LIBRARIES})
+      ${catkin_LIBRARIES}
+      ${OpenCV_LIBS})
     cisst_target_link_libraries (atracsys ${REQUIRED_CISST_LIBRARIES})
 
     install (TARGETS atracsys

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -78,7 +78,7 @@ if (cisst_FOUND_AS_REQUIRED)
     include_directories (${CATKIN_DEVEL_PREFIX}/include ${sawAtracsysFusionTrack_INCLUDE_DIR})
     link_directories (${sawAtracsysFusionTrack_LIBRARY_DIR})
 
-    add_executable (atracsys src/atracsys.cpp src/mts_ros_crtk_atracsys_bridge.cpp src/mts_ros_crtk_atracsys_bridge.h)
+    add_executable (atracsys src/atracsys.cpp src/atracsys_bridge.cpp src/atracsys_bridge.h)
     target_link_libraries (atracsys
       ${sawAtracsysFusionTrack_LIBRARIES}
       ${catkin_LIBRARIES}

--- a/ros/src/atracsys.cpp
+++ b/ros/src/atracsys.cpp
@@ -81,6 +81,11 @@ int main(int argc, char * argv[])
     mtsAtracsysFusionTrack * tracker = new mtsAtracsysFusionTrack("atracsys");
     tracker->Configure(jsonConfigFile);
 
+    if (!tracker->HardwareInitialized()) {
+        CMN_LOG_INIT_ERROR << "Failed to initialize Atracsys hardware --- is device connected and powered on?" << std::endl;
+        return -1;
+    }
+
     mtsAtracsysStereo * stereo = new mtsAtracsysStereo("stereo", tracker->GetName());
     stereo->Configure(jsonConfigFile);
 

--- a/ros/src/atracsys.cpp
+++ b/ros/src/atracsys.cpp
@@ -26,7 +26,7 @@ http://www.cisst.org/cisst/license.txt.
 #include <sawAtracsysFusionTrack/mtsAtracsysStereo.h>
 #include <sawAtracsysFusionTrack/mtsAtracsysFusionTrackStrayMarkersQtWidget.h>
 
-#include "mts_ros_crtk_atracsys_bridge.h"
+#include "atracsys_bridge.h"
 
 #include <QApplication>
 #include <QMainWindow>
@@ -97,14 +97,13 @@ int main(int argc, char * argv[])
                               stereo->GetName(), "StereoRaw");
 
     // ROS CRTK bridge
-    mts_ros_crtk_atracsys_bridge * crtk_bridge
-        = new mts_ros_crtk_atracsys_bridge("atracsys_crtk_bridge", rosNode);
+    atracsys_bridge * bridge = new atracsys_bridge("atracsys_bridge", rosNode);
 
-    crtk_bridge->bridge(tracker->GetName(), "Controller", rosPeriod, tfPeriod);
-    crtk_bridge->bridge_interface_provided(stereo->GetName(), "stereo", tracker->GetName() + "/stereo", rosPeriod, tfPeriod);
+    bridge->bridge(tracker->GetName(), "Controller", rosPeriod, tfPeriod);
+    bridge->bridge_interface_provided(stereo->GetName(), "stereo", tracker->GetName() + "/stereo", rosPeriod, tfPeriod);
 
-    componentManager->AddComponent(crtk_bridge);
-    crtk_bridge->Connect();
+    componentManager->AddComponent(bridge);
+    bridge->Connect();
 
     // create a Qt user interface
     QApplication application(argc, argv);

--- a/ros/src/atracsys.cpp
+++ b/ros/src/atracsys.cpp
@@ -101,14 +101,7 @@ int main(int argc, char * argv[])
         = new mts_ros_crtk_atracsys_bridge("atracsys_crtk_bridge", rosNode);
 
     crtk_bridge->bridge(tracker->GetName(), "Controller", rosPeriod, tfPeriod);
-    std::string stereo_namespace = tracker->GetName() + "/stereo";
-    cisst_ral::clean_namespace(stereo_namespace);
-    crtk_bridge->bridge_interface_provided(stereo->GetName(), "stereo", stereo_namespace, rosPeriod, tfPeriod);
-
-    auto num_tools = tracker->GetNumberOfTools();
-    for (size_t i = 0; i < num_tools; ++i) {
-        crtk_bridge->bridge_tool_error(tracker->GetName(), tracker->GetToolName(i));
-    }
+    crtk_bridge->bridge_interface_provided(stereo->GetName(), "stereo", tracker->GetName() + "/stereo", rosPeriod, tfPeriod);
 
     componentManager->AddComponent(crtk_bridge);
     crtk_bridge->Connect();

--- a/ros/src/atracsys.cpp
+++ b/ros/src/atracsys.cpp
@@ -97,12 +97,12 @@ int main(int argc, char * argv[])
                               stereo->GetName(), "StereoRaw");
 
     // ROS CRTK bridge
-    atracsys_bridge * bridge = new atracsys_bridge("atracsys_bridge", rosNode);
-
-    bridge->bridge(tracker->GetName(), "Controller", rosPeriod, tfPeriod);
-    bridge->bridge_interface_provided(stereo->GetName(), "stereo", tracker->GetName() + "/stereo", rosPeriod, tfPeriod);
-
+    atracsys_bridge * bridge = new atracsys_bridge("atracsys_bridge", rosNode, rosPeriod, tfPeriod);
     componentManager->AddComponent(bridge);
+
+    bridge->bridge_controller(tracker->GetName(), "Controller");
+    bridge->bridge_stereo(stereo->GetName(), "stereo", tracker->GetName() + "/stereo");
+
     bridge->Connect();
 
     // create a Qt user interface

--- a/ros/src/atracsys_bridge.cpp
+++ b/ros/src/atracsys_bridge.cpp
@@ -81,6 +81,10 @@ void atracsys_bridge::bridge_stereo(const std::string & _component_name,
     std::string clean_namespace = _ros_namespace;
     cisst_ral::clean_namespace(clean_namespace);
 
+    // bridge all CRTK-compatible topics from the controller
+    bridge_interface_provided(_component_name, _interface_name, clean_namespace,
+                              m_ros_period, m_tf_period);
+
     m_pub_bridge->AddPublisherFromCommandRead<prmImageFrame, CISST_RAL_MSG(sensor_msgs, Image)>
         (_interface_name, "left/image_rect_color", clean_namespace + "/left/image_rect_color");
 

--- a/ros/src/atracsys_bridge.cpp
+++ b/ros/src/atracsys_bridge.cpp
@@ -21,66 +21,118 @@ http://www.cisst.org/cisst/license.txt.
 #include <algorithm>
 #include <iostream>
 
-// cisst
+#include <cisst_ros_bridge/cisst_ral.h>
 #include <cisst_ros_bridge/mtsROSBridge.h>
+#include <cisstMultiTask/mtsManagerComponentServices.h>
 
 CMN_IMPLEMENT_SERVICES(atracsys_bridge);
 
-void atracsys_bridge::bridge(const std::string & _component_name,
-                                          const std::string & _interface_name,
-                                          const double _publish_period_in_seconds,
-                                          const double _tf_period_in_seconds)
+atracsys_bridge::atracsys_bridge(const std::string& _component_name,
+                                 cisst_ral::node_ptr_t _node_handle,
+                                 double ros_period,
+                                 double tf_period):
+    mts_ros_crtk_bridge_provided(_component_name, _node_handle, ros_period),
+    m_ros_period(ros_period),
+    m_tf_period(tf_period)
 {
+    mtsManagerLocal* componentManager = mtsManagerLocal::GetInstance();
+
+    std::string m_bridge_name = GetName() + "_pub";
+    cisst_ral::clean_namespace(m_bridge_name);
+
+    m_pub_bridge = new mtsROSBridge(m_bridge_name, ros_period, _node_handle);
+    m_pub_bridge->AddIntervalStatisticsInterface();
+    componentManager->AddComponent(m_pub_bridge);
+
+    // add pub bridge stats to the stats bridge from the base class
+    stats_bridge().AddIntervalStatisticsPublisher("publishers", m_pub_bridge->GetName());
+}
+
+void atracsys_bridge::bridge_controller(const std::string & _component_name,
+                                        const std::string & _interface_name)
+{
+    std::string required_interface_name = GetName() + "_" + _component_name + "_using_" + _interface_name + "_factory";
+    mtsInterfaceRequired* required_interface = AddInterfaceRequired(required_interface_name);
+
+    if (!required_interface) {
+        CMN_LOG_CLASS_INIT_ERROR << "bridge_controller: couldn't add required interface for factory source"  << std::endl;
+    }
+
+    required_interface->AddFunction("crtk_interfaces_provided", m_get_factory_sources);
+    required_interface->AddEventHandlerVoid(&atracsys_bridge::sources_update_handler, this,
+                                  "crtk_interfaces_provided_updated");
+
+    mtsManagerLocal* componentManager = mtsManagerLocal::GetInstance();
+    componentManager->Connect(GetName(), required_interface_name, _component_name, _interface_name);
+
     // clean ROS namespace
-    std::string _clean_namespace = _component_name;
-    cisst_ral::clean_namespace(_clean_namespace);
+    std::string clean_namespace = _component_name;
+    cisst_ral::clean_namespace(clean_namespace);
 
-    // create factory to bridge tool as they get created
-    add_factory_source(_component_name,
-                             _interface_name,
-                             _publish_period_in_seconds,
-                             _tf_period_in_seconds);
-
-    // controller specific topics, some might be CRTK compliant
-    bridge_interface_provided(_component_name,
-                                    _interface_name,
-                                    _clean_namespace,
-                                    _publish_period_in_seconds,
-                                    _tf_period_in_seconds);
+    // bridge all CRTK-compatible topics from the controller
+    bridge_interface_provided(_component_name, _interface_name, clean_namespace,
+                              m_ros_period, m_tf_period);
 }
 
-void atracsys_bridge::bridge_interface_provided(const std::string & _component_name,
-                                          const std::string & _interface_name,
-                                          const double _publish_period_in_seconds,
-                                          const double _tf_period_in_seconds) {
-    // bridge CRTK topics
-    mts_ros_crtk_bridge::bridge_interface_provided(_component_name, _interface_name,
-                                                   _publish_period_in_seconds, _tf_period_in_seconds);
-    // and also the registration_error command (if present)
-    bridge_tool_error(_component_name, _interface_name);
-}
-
-void atracsys_bridge::bridge_tool_error(const std::string & _component_name,
-                                                     const std::string & _interface_name)
+void atracsys_bridge::bridge_stereo(const std::string & _component_name,
+                                    const std::string & _interface_name,
+                                    const std::string & _ros_namespace)
 {
-    mtsManagerLocal * _component_manager = mtsComponentManager::GetInstance();
-    mtsComponent * _component = _component_manager->GetComponent(_component_name);
-    if (!_component) {
-        CMN_LOG_CLASS_RUN_ERROR << "bridge_tool_error: unable to find component \""
-                                 << _component_name << "\"" << std::endl;
-        return;
-    }
-    // then try to find the interface
-    mtsInterfaceProvided * _interface_provided = _component->GetInterfaceProvided(_interface_name);
+    std::string clean_namespace = _ros_namespace;
+    cisst_ral::clean_namespace(clean_namespace);
 
-    // check if interface provides tool registration error
-    const auto& read_commands = _interface_provided->GetNamesOfCommandsRead();
-    if (std::find(read_commands.begin(), read_commands.end(), "registration_error") == read_commands.end()) {
-        return;
-    }
+    m_pub_bridge->AddPublisherFromCommandRead<prmImageFrame, CISST_RAL_MSG(sensor_msgs, Image)>
+        (_interface_name, "left/image_rect_color", clean_namespace + "/left/image_rect_color");
 
-    std::string ros_topic = _component_name + "/" + _interface_name + "/registration_error";
+    m_pub_bridge->AddPublisherFromCommandRead<prmImageFrame, CISST_RAL_MSG(sensor_msgs, Image)>
+        (_interface_name, "right/image_rect_color", clean_namespace + "/right/image_rect_color");
 
-    m_subscribers_bridge->AddPublisherFromCommandRead<double, CISST_RAL_MSG(std_msgs, Float64)>
+    m_pub_bridge->AddPublisherFromCommandRead<prmCameraInfo, CISST_RAL_MSG(sensor_msgs, CameraInfo)>
+        (_interface_name, "left/camera_info", clean_namespace + "/left/camera_info");
+
+    m_pub_bridge->AddPublisherFromCommandRead<prmCameraInfo, CISST_RAL_MSG(sensor_msgs, CameraInfo)>
+        (_interface_name, "right/camera_info", clean_namespace + "/right/camera_info");
+
+    m_pub_bridge->AddPublisherFromCommandRead<prmDepthMap, CISST_RAL_MSG(sensor_msgs, PointCloud2)>
+        (_interface_name, "depth", clean_namespace + "/depth");
+
+    mtsManagerLocal* componentManager = mtsManagerLocal::GetInstance();
+    componentManager->Connect(m_pub_bridge->GetName(), _interface_name, _component_name, _interface_name);
+}
+
+void atracsys_bridge::bridge_tool(const std::string & _component_name,
+                                  const std::string & _interface_name,
+                                  const std::string & _ros_namespace)
+{
+    std::string clean_namespace = _ros_namespace;
+    cisst_ral::clean_namespace(clean_namespace);
+    std::string ros_topic = clean_namespace + "/registration_error";
+
+    m_pub_bridge->AddPublisherFromCommandRead<double, CISST_RAL_MSG(std_msgs, Float64)>
         (_interface_name, "registration_error", ros_topic);
+
+    mtsManagerLocal* componentManager = mtsManagerLocal::GetInstance();
+    componentManager->Connect(m_pub_bridge->GetName(), _interface_name, _component_name, _interface_name);
+}
+
+void atracsys_bridge::sources_update_handler()
+{
+    std::vector<mtsDescriptionInterfaceFullName> sources;
+    m_get_factory_sources(sources);
+    for (const auto & source : sources) {
+        // skip any sources bridged previously
+        if (m_bridged_sources.find(source) != m_bridged_sources.end()) {
+            continue;
+        }
+
+        std::string ros_namespace = source.ComponentName + "/" + source.InterfaceName;
+        cisst_ral::clean_namespace(ros_namespace);
+        bridge_interface_provided(source.ComponentName,
+                                  source.InterfaceName,
+                                  ros_namespace,
+                                  m_ros_period, m_tf_period);
+        bridge_tool(source.ComponentName, source.InterfaceName, ros_namespace);
+        Connect();
+        m_bridged_sources.insert(source);
+    }
 }

--- a/ros/src/atracsys_bridge.cpp
+++ b/ros/src/atracsys_bridge.cpp
@@ -98,7 +98,7 @@ void atracsys_bridge::bridge_stereo(const std::string & _component_name,
         (_interface_name, "right/camera_info", clean_namespace + "/right/camera_info");
 
     m_pub_bridge->AddPublisherFromCommandRead<prmDepthMap, CISST_RAL_MSG(sensor_msgs, PointCloud2)>
-        (_interface_name, "depth", clean_namespace + "/depth");
+        (_interface_name, "pointcloud", clean_namespace + "/pointcloud");
 
     mtsManagerLocal* componentManager = mtsManagerLocal::GetInstance();
     componentManager->Connect(m_pub_bridge->GetName(), _interface_name, _component_name, _interface_name);

--- a/ros/src/atracsys_bridge.cpp
+++ b/ros/src/atracsys_bridge.cpp
@@ -16,7 +16,7 @@ http://www.cisst.org/cisst/license.txt.
 --- end cisst license ---
 */
 
-#include "mts_ros_crtk_atracsys_bridge.h"
+#include "atracsys_bridge.h"
 
 #include <algorithm>
 #include <iostream>
@@ -24,9 +24,9 @@ http://www.cisst.org/cisst/license.txt.
 // cisst
 #include <cisst_ros_bridge/mtsROSBridge.h>
 
-CMN_IMPLEMENT_SERVICES(mts_ros_crtk_atracsys_bridge);
+CMN_IMPLEMENT_SERVICES(atracsys_bridge);
 
-void mts_ros_crtk_atracsys_bridge::bridge(const std::string & _component_name,
+void atracsys_bridge::bridge(const std::string & _component_name,
                                           const std::string & _interface_name,
                                           const double _publish_period_in_seconds,
                                           const double _tf_period_in_seconds)
@@ -49,7 +49,7 @@ void mts_ros_crtk_atracsys_bridge::bridge(const std::string & _component_name,
                                     _tf_period_in_seconds);
 }
 
-void mts_ros_crtk_atracsys_bridge::bridge_interface_provided(const std::string & _component_name,
+void atracsys_bridge::bridge_interface_provided(const std::string & _component_name,
                                           const std::string & _interface_name,
                                           const double _publish_period_in_seconds,
                                           const double _tf_period_in_seconds) {
@@ -60,7 +60,7 @@ void mts_ros_crtk_atracsys_bridge::bridge_interface_provided(const std::string &
     bridge_tool_error(_component_name, _interface_name);
 }
 
-void mts_ros_crtk_atracsys_bridge::bridge_tool_error(const std::string & _component_name,
+void atracsys_bridge::bridge_tool_error(const std::string & _component_name,
                                                      const std::string & _interface_name)
 {
     mtsManagerLocal * _component_manager = mtsComponentManager::GetInstance();

--- a/ros/src/atracsys_bridge.h
+++ b/ros/src/atracsys_bridge.h
@@ -19,38 +19,39 @@ http://www.cisst.org/cisst/license.txt.
 #ifndef _atracsys_bridge_h
 #define _atracsys_bridge_h
 
-#include <cisst_ros_crtk/mts_ros_crtk_bridge.h>
+#include <cisst_ros_crtk/mts_ros_crtk_bridge_provided.h>
 
-class atracsys_bridge: public mts_ros_crtk_bridge
+class atracsys_bridge: public mts_ros_crtk_bridge_provided
 {
     CMN_DECLARE_SERVICES(CMN_NO_DYNAMIC_CREATION, CMN_LOG_ALLOW_DEFAULT);
 
- public:
-    inline atracsys_bridge(const std::string & _component_name,
-                                        cisst_ral::node_ptr_t _node_handle,
-                                        const double _period_in_seconds = 5.0 * cmn_ms):
-        mts_ros_crtk_bridge(_component_name, _node_handle, _period_in_seconds)
-    {}
+public:
+    atracsys_bridge(const std::string& component_name,
+                    cisst_ral::node_ptr_t node_handle,
+                    double ros_period = 5.0 * cmn_ms,
+                    double tf_period = 5.0 * cmn_ms);
 
-    inline ~atracsys_bridge() {}
+    void bridge_controller(const std::string& _component_name,
+                const std::string& _interface_name);
 
-    /*! Everything needed to bridge the sawAtracsysTracker component */
-    void bridge(const std::string & _component_name,
+    void bridge_stereo(const std::string & _component_name,
                 const std::string & _interface_name,
-                const double _publish_period_in_seconds,
-                const double _tf_period_in_seconds);
+                const std::string & _ros_namespace);
 
-    using mts_ros_crtk_bridge::bridge_interface_provided; // bring all overloads into scope before overriding
+protected:
+    mtsROSBridge* m_pub_bridge;
 
-    virtual void bridge_interface_provided(const std::string & _component_name,
-                                          const std::string & _interface_name,
-                                          const double _publish_period_in_seconds
-                                          = cisst_ros_crtk::bridge_provided_default_publish_period,
-                                          const double _tf_period_in_seconds
-                                          = cisst_ros_crtk::bridge_provided_default_tf_period) override;
+    const double m_ros_period;
+    const double m_tf_period;
 
-    void bridge_tool_error(const std::string & _component_name,
-                           const std::string & _interface_name);
+    // source factory for tools
+    mtsFunctionRead m_get_factory_sources;
+    std::set<mtsDescriptionInterfaceFullName> m_bridged_sources;
+    void sources_update_handler();
+
+    void bridge_tool(const std::string & _component_name,
+                     const std::string & _interface_name,
+                     const std::string & _ros_namespace);
 };
 
 CMN_DECLARE_SERVICES_INSTANTIATION(atracsys_bridge);

--- a/ros/src/atracsys_bridge.h
+++ b/ros/src/atracsys_bridge.h
@@ -16,23 +16,23 @@ http://www.cisst.org/cisst/license.txt.
 --- end cisst license ---
 */
 
-#ifndef _mts_ros_crtk_atracsys_bridge_h
-#define _mts_ros_crtk_atracsys_bridge_h
+#ifndef _atracsys_bridge_h
+#define _atracsys_bridge_h
 
 #include <cisst_ros_crtk/mts_ros_crtk_bridge.h>
 
-class mts_ros_crtk_atracsys_bridge: public mts_ros_crtk_bridge
+class atracsys_bridge: public mts_ros_crtk_bridge
 {
     CMN_DECLARE_SERVICES(CMN_NO_DYNAMIC_CREATION, CMN_LOG_ALLOW_DEFAULT);
 
  public:
-    inline mts_ros_crtk_atracsys_bridge(const std::string & _component_name,
+    inline atracsys_bridge(const std::string & _component_name,
                                         cisst_ral::node_ptr_t _node_handle,
                                         const double _period_in_seconds = 5.0 * cmn_ms):
         mts_ros_crtk_bridge(_component_name, _node_handle, _period_in_seconds)
     {}
 
-    inline ~mts_ros_crtk_atracsys_bridge() {}
+    inline ~atracsys_bridge() {}
 
     /*! Everything needed to bridge the sawAtracsysTracker component */
     void bridge(const std::string & _component_name,
@@ -53,6 +53,6 @@ class mts_ros_crtk_atracsys_bridge: public mts_ros_crtk_bridge
                            const std::string & _interface_name);
 };
 
-CMN_DECLARE_SERVICES_INSTANTIATION(mts_ros_crtk_atracsys_bridge);
+CMN_DECLARE_SERVICES_INSTANTIATION(atracsys_bridge);
 
-#endif // _mts_ros_crtk_atracsys_bridge_h
+#endif // _atracsys_bridge_h

--- a/ros/src/mts_ros_crtk_atracsys_bridge.cpp
+++ b/ros/src/mts_ros_crtk_atracsys_bridge.cpp
@@ -16,11 +16,12 @@ http://www.cisst.org/cisst/license.txt.
 --- end cisst license ---
 */
 
-// system include
+#include "mts_ros_crtk_atracsys_bridge.h"
+
+#include <algorithm>
 #include <iostream>
 
 // cisst
-#include "mts_ros_crtk_atracsys_bridge.h"
 #include <cisst_ros_bridge/mtsROSBridge.h>
 
 CMN_IMPLEMENT_SERVICES(mts_ros_crtk_atracsys_bridge);
@@ -35,51 +36,51 @@ void mts_ros_crtk_atracsys_bridge::bridge(const std::string & _component_name,
     cisst_ral::clean_namespace(_clean_namespace);
 
     // create factory to bridge tool as they get created
-    this->add_factory_source(_component_name,
+    add_factory_source(_component_name,
                              _interface_name,
                              _publish_period_in_seconds,
                              _tf_period_in_seconds);
 
     // controller specific topics, some might be CRTK compliant
-    this->bridge_interface_provided(_component_name,
+    bridge_interface_provided(_component_name,
                                     _interface_name,
                                     _clean_namespace,
                                     _publish_period_in_seconds,
                                     _tf_period_in_seconds);
+}
 
-    // non CRTK topics
-    // add trailing / for clean namespace
-    if (!_clean_namespace.empty()) {
-        _clean_namespace.append("/");
-    }
-
-    // required interfaces specific to this component to bridge
-    const std::string _required_interface_name = _component_name + "_using_" + _interface_name;
-
-    // connections
-    m_connections.Add(m_subscribers_bridge->GetName(), _required_interface_name,
-                      _component_name, _interface_name);
-    m_connections.Add(m_events_bridge->GetName(), _required_interface_name,
-                      _component_name, _interface_name);
+void mts_ros_crtk_atracsys_bridge::bridge_interface_provided(const std::string & _component_name,
+                                          const std::string & _interface_name,
+                                          const double _publish_period_in_seconds,
+                                          const double _tf_period_in_seconds) {
+    // bridge CRTK topics
+    mts_ros_crtk_bridge::bridge_interface_provided(_component_name, _interface_name,
+                                                   _publish_period_in_seconds, _tf_period_in_seconds);
+    // and also the registration_error command (if present)
+    bridge_tool_error(_component_name, _interface_name);
 }
 
 void mts_ros_crtk_atracsys_bridge::bridge_tool_error(const std::string & _component_name,
                                                      const std::string & _interface_name)
 {
-    std::string _clean_namespace = _component_name;
-    cisst_ral::clean_namespace(_clean_namespace);
-
-    // add trailing / for clean namespace
-    if (!_clean_namespace.empty()) {
-        _clean_namespace.append("/");
+    mtsManagerLocal * _component_manager = mtsComponentManager::GetInstance();
+    mtsComponent * _component = _component_manager->GetComponent(_component_name);
+    if (!_component) {
+        CMN_LOG_CLASS_RUN_ERROR << "bridge_tool_error: unable to find component \""
+                                 << _component_name << "\"" << std::endl;
+        return;
     }
-    // required interfaces specific to this component to bridge
-    const std::string _required_interface_name = _component_name + "_using_" + _interface_name;
+    // then try to find the interface
+    mtsInterfaceProvided * _interface_provided = _component->GetInterfaceProvided(_interface_name);
 
-    // non CRTK topics
+    // check if interface provides tool registration error
+    const auto& read_commands = _interface_provided->GetNamesOfCommandsRead();
+    if (std::find(read_commands.begin(), read_commands.end(), "registration_error") == read_commands.end()) {
+        return;
+    }
+
+    std::string ros_topic = _component_name + "/" + _interface_name + "/registration_error";
+
     m_subscribers_bridge->AddPublisherFromCommandRead<double, CISST_RAL_MSG(std_msgs, Float64)>
-        (_required_interface_name, "registration_error", _component_name + "/" + _interface_name + "/registration_error");
-
-    m_connections.Add(m_subscribers_bridge->GetName(), _required_interface_name,
-                      _component_name, _interface_name);
+        (_interface_name, "registration_error", ros_topic);
 }

--- a/ros/src/mts_ros_crtk_atracsys_bridge.cpp
+++ b/ros/src/mts_ros_crtk_atracsys_bridge.cpp
@@ -52,6 +52,7 @@ void mts_ros_crtk_atracsys_bridge::bridge(const std::string & _component_name,
     if (!_clean_namespace.empty()) {
         _clean_namespace.append("/");
     }
+
     // required interfaces specific to this component to bridge
     const std::string _required_interface_name = _component_name + "_using_" + _interface_name;
 

--- a/ros/src/mts_ros_crtk_atracsys_bridge.h
+++ b/ros/src/mts_ros_crtk_atracsys_bridge.h
@@ -40,6 +40,15 @@ class mts_ros_crtk_atracsys_bridge: public mts_ros_crtk_bridge
                 const double _publish_period_in_seconds,
                 const double _tf_period_in_seconds);
 
+    using mts_ros_crtk_bridge::bridge_interface_provided; // bring all overloads into scope before overriding
+
+    virtual void bridge_interface_provided(const std::string & _component_name,
+                                          const std::string & _interface_name,
+                                          const double _publish_period_in_seconds
+                                          = cisst_ros_crtk::bridge_provided_default_publish_period,
+                                          const double _tf_period_in_seconds
+                                          = cisst_ros_crtk::bridge_provided_default_tf_period) override;
+
     void bridge_tool_error(const std::string & _component_name,
                            const std::string & _interface_name);
 };


### PR DESCRIPTION
Adds stereo processing to produce dense point clouds from scene for the spryTrack cameras.

The mtsAtracsysFusionTrack component requires raw stereo images from camera and provides them via a "StereoRaw" interface. The separate mtsAtracsysStereo component handles all image rectification and stereo reconstruction. Stereo processing is configurable via the JSON config file, and config options are documented in the README (alongside a little advice).

Depends on https://github.com/jhu-cisst/cisst-ros/pull/23 and https://github.com/jhu-cisst/cisst/pull/101.